### PR TITLE
Expose service ports

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -329,7 +329,7 @@ services:
           memory: 65M
     restart: unless-stopped
     ports:
-      - "${ENVOY_PORT}"
+      - "${ENVOY_PORT}:${ENVOY_PORT}"
       - 10000
     environment:
       - FRONTEND_PORT

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -330,7 +330,7 @@ services:
     restart: unless-stopped
     ports:
       - "${ENVOY_PORT}:${ENVOY_PORT}"
-      - 10000
+      - 10000:10000
     environment:
       - FRONTEND_PORT
       - FRONTEND_HOST
@@ -730,8 +730,6 @@ services:
         limits:
           memory: 1024M
     restart: unless-stopped
-    environment:
-      - "GF_INSTALL_PLUGINS=grafana-opensearch-datasource"
     volumes:
       - ./src/grafana/grafana.ini:/etc/grafana/grafana.ini
       - ./src/grafana/provisioning/:/etc/grafana/provisioning/
@@ -794,7 +792,7 @@ services:
           memory: 300M
     restart: unless-stopped
     ports:
-      - "${PROMETHEUS_PORT}"
+      - "${PROMETHEUS_PORT}:${PROMETHEUS_PORT}"
     logging: *logging
 
   # Doris


### PR DESCRIPTION
Expose `PROMETHEUS_PORT` and `ENVOY_PROXY` as otherwise the whole setup doesn't work (Maybe on other versions or machines)

```bash
$ docker --version
Docker version 28.1.1, build 4eba377

$ uname -r
6.14.6-300.fc42.x86_64
```
