### PR TITLE
ci: pin third-party GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/assign-reviewers.yml
+++ b/.github/workflows/assign-reviewers.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.repository == 'open-telemetry/opentelemetry-demo'
     runs-on: ubuntu-latest
     steps:
-      - uses: dyladan/component-owners@main
+      - uses: dyladan/component-owners@7ff2b343629407c4dbe1c28ae66f55f723543d2b # main
         with:
           # using this action to request review only (not assignment)
           assign-owners: false

--- a/.github/workflows/checks.yml
+++ b/.github/workflows/checks.yml
@@ -53,7 +53,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - name: Run linkspector
-        uses: umbrelladocs/action-linkspector@v1
+        uses: umbrelladocs/action-linkspector@ec40914b4aaecb3c7648033eac41abbb0a6a33b8 # v1
         with:
           level: info
           fail_level: any

--- a/.github/workflows/gradle-wrapper-validation.yml
+++ b/.github/workflows/gradle-wrapper-validation.yml
@@ -15,4 +15,4 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - uses: gradle/actions/wrapper-validation@v4.3.0
+      - uses: gradle/actions/wrapper-validation@94baf225fe0a508e581a564467443d0e2379123b # v4.3.0

--- a/.github/workflows/label-pr.yml
+++ b/.github/workflows/label-pr.yml
@@ -19,7 +19,7 @@ jobs:
 
       - name: Check for changed files
         id: file_changes
-        uses: dorny/paths-filter@v3
+        uses: dorny/paths-filter@6852f92c20ea7fd3b0c25de3b5112db3a98da050 # v3
         with:
           list-files: shell
           filters: |


### PR DESCRIPTION
A few workflows here call third-party actions by mutable refs (one even uses a branch, `dyladan/component-owners@main`). Branch and tag refs can be repointed at any time by the action's maintainers, so whatever lives at that ref is what runs with access to the workflow's token and secrets. The tj-actions/changed-files compromise (CVE-2025-30066) demonstrated the impact: tags were rewritten to malicious commits and CI secrets leaked downstream before anyone noticed.

Pinning to the exact commit SHA closes that gap. I resolved each ref to its current commit and recorded the original tag or branch name in a trailing comment so upgrades stay straightforward:

- `dyladan/component-owners@main` in assign-reviewers.yml
- `umbrelladocs/action-linkspector@v1` in checks.yml
- `gradle/actions/wrapper-validation@v4.3.0` in gradle-wrapper-validation.yml
- `dorny/paths-filter@v3` in label-pr.yml

I left the reusable `component-build-images.yml` (`on: workflow_call`) untouched on purpose, since that one is better handled together with whatever pins its caller. GitHub-maintained `actions/*` were also left as-is. This nudges the Pinned-Dependencies score in the right direction.